### PR TITLE
Add first release of docserv

### DIFF
--- a/docs/conf.d/config.toml
+++ b/docs/conf.d/config.toml
@@ -1,0 +1,3 @@
+["docsrv.sourced.tech"]
+  repository = "src-d/docsrv"
+  min-version = "v0.1"


### PR DESCRIPTION
depends on
- https://github.com/src-d/docsrv/pull/20
- creation of a v0.1 release on https://github.com/src-d/docsrv/releases