### PR TITLE
 add glide support

### DIFF
--- a/.tests.bash
+++ b/.tests.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-EXAMPLES=examples/ci
+EXAMPLES="examples/ci examples/glide"
 
 for example in ${EXAMPLES} ; do
 	echo "Running $example"

--- a/.tests.bash
+++ b/.tests.bash
@@ -8,6 +8,8 @@ for example in ${EXAMPLES} ; do
 	cp Makefile.main ${example}/Makefile.main
 	pushd $example &> /dev/null
 
+	make dependencies
+
 	make test
 
 	make test-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: go
 go:
   - 1.8
 
+install:
+  - echo "pass"
+
 script:
   - ./.tests.bash
 

--- a/Makefile.main
+++ b/Makefile.main
@@ -53,7 +53,17 @@ COVERAGE_REPORT = coverage.txt
 COVERAGE_PROFILE = profile.out
 COVERAGE_MODE = atomic
 
-PACKAGES = $(shell go list)
+# Glide
+GLIDE_LOCK = glide.lock
+ifneq ("$(wildcard $(GLIDE_LOCK))","")
+VENDOR_PATH = $(WORKDIR)/vendor
+GLIDE = glide
+DEPENDENCIES += github.com/Masterminds/glide
+else
+VENDOR_PATH =
+endif
+
+PACKAGES = $(shell go list | grep -v '/vendor/')
 
 # Rules
 
@@ -155,5 +165,5 @@ test-coverage:
 	bash <(curl -s https://codecov.io/bash) $${args}; \
 
 clean:
-	rm -rf $(BUILD_PATH)
+	rm -rf $(BUILD_PATH) $(VENDOR_PATH)
 	$(GOCLEAN) .

--- a/Makefile.main
+++ b/Makefile.main
@@ -53,18 +53,22 @@ COVERAGE_REPORT = coverage.txt
 COVERAGE_PROFILE = profile.out
 COVERAGE_MODE = atomic
 
+PACKAGES = $(shell go list)
+
 # Rules
-dependencies:
-	@for i in $(DEPENDENCIES); do $(GOGET) $$i; done; \
-	retries=0; \
-	while [[ $$retries < 3 ]]; do \
-		cd $(WORKDIR) && $(GOGET) ./...; \
-		if [ $$? == 0 ]; then \
-			break; \
-		fi; \
-		sleep 2; \
-		((retries++)); \
-	done;
+
+.PHONY: $(DEPENDENCIES) $(PACKAGES) dependencies docker-push packages test test-coverage pre-run post-run clean
+
+$(DEPENDENCIES):
+	$(GOGET) $@/...
+
+$(VENDOR_PATH): $(GLIDE_LOCK)
+	$(GLIDE) install
+
+$(PACKAGES): $(VENDOR_PATH)
+	$(GOGET) $@
+
+dependencies: $(DEPENDENCIES) $(VENDOR_PATH) $(PACKAGES)
 
 docker-push:
 	@if [ "$(BRANCH)" == "master" ]; then \
@@ -130,12 +134,12 @@ pre-run:
 	done; \
 
 test:
-	$(GOTEST) ./...
+	$(GOTEST) $(PACKAGES)
 
 test-coverage:
 	@cd $(WORKDIR); \
 	echo "" > $(COVERAGE_REPORT); \
-	for dir in `find . -name "*.go" | grep -o '.*/' | sort -u`; do \
+	for dir in $(PACKAGES); do \
 		$(GOTEST) $$dir -coverprofile=$(COVERAGE_PROFILE) -covermode=$(COVERAGE_MODE); \
 		if [ $$? != 0 ]; then \
 			exit 2; \

--- a/examples/glide/.travis.yml
+++ b/examples/glide/.travis.yml
@@ -1,0 +1,36 @@
+language: go
+
+go:
+  - 1.8
+  - tip
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - go: tip
+
+sudo: required
+
+services:
+  - docker
+
+install:
+  - make dependencies
+
+script:
+  - make test-coverage
+
+before_deploy:
+  - make packages
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_TOKEN 
+  file_glob: true
+  file: build/*.tar.gz
+  skip_cleanup: true
+  on:
+    tags: true
+
+after_deploy:
+  - make docker-push

--- a/examples/glide/Makefile
+++ b/examples/glide/Makefile
@@ -1,0 +1,18 @@
+# Package configuration
+PROJECT = ci
+COMMANDS = cmd/test
+#CODECOV_TOKEN = your codecov token
+
+# Including ci Makefile
+MAKEFILE = Makefile.main
+CI_REPOSITORY = https://github.com/src-d/ci.git
+CI_FOLDER = .ci
+
+# If you need to build more than one dockerfile, you can do so like this:
+# DOCKERFILES = Dockerfile_filename1:repositoryname1 Dockerfile_filename2:repositoryname2 ...
+
+$(MAKEFILE):
+	@git clone --quiet $(CI_REPOSITORY) $(CI_FOLDER); \
+	cp $(CI_FOLDER)/$(MAKEFILE) .;
+
+-include $(MAKEFILE)

--- a/examples/glide/cmd/test/main.go
+++ b/examples/glide/cmd/test/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/src-d/ci/examples/ci"
+
+func main() {
+	ci.HelloWorld()
+}

--- a/examples/glide/example.go
+++ b/examples/glide/example.go
@@ -1,0 +1,12 @@
+// Package ci is just an example.
+package ci
+
+import (
+	"my.vendor/lib"
+	"fmt"
+)
+
+func HelloWorld() {
+	fmt.Println(errors.New("Hello World").Error())
+}
+

--- a/examples/glide/example_test.go
+++ b/examples/glide/example_test.go
@@ -1,0 +1,10 @@
+// Package ci is just an example.
+package ci
+
+import (
+	"testing"
+)
+
+func TestHelloWorld(t *testing.T) {
+	HelloWorld()
+}

--- a/examples/glide/glide.lock
+++ b/examples/glide/glide.lock
@@ -1,0 +1,11 @@
+hash: f6bddc3d90d52b6061ff53dc928c3bec8144b537145cd597731d54b5220c28f5
+updated: 2017-06-30T15:49:19.761648304+02:00
+imports:
+- name: github.com/src-d/ci
+  version: a30c0a3cd198346f83574b4be20beaa07f64be15
+  subpackages:
+  - examples/ci
+- name: my.vendor/lib
+  version: bfd5150e4e41705ded2129ec33379de1cb90b513
+  repo: https://github.com/pkg/errors
+testImports: []

--- a/examples/glide/glide.yaml
+++ b/examples/glide/glide.yaml
@@ -1,0 +1,4 @@
+package: github.com/src-d/ci/examples/glide
+import:
+- package: my.vendor/lib
+  repo: https://github.com/pkg/errors


### PR DESCRIPTION
* If glide.lock file is present in the same directory make is being
  executed, then glide is enabled.
* When glide is disabled, everything should work just as before this
  commit.
* When glide is enabled:
  * github.com/Masterminds/glide is added to DEPENDENCIES, so it will
    be installed by `make dependencies` early.
    Note that either $GOPATH/bin should be in $PATH for this to work
    or `glide` binary should be present in $PATH.
  * `glide install` will be run by `make dependencies`.

This PR also includes some clean ups that make it easier to implement glide:
* Rules are defined as .PHONY where relevant.
* dependencies rule refactored out into rules that match each dependency
  and package.
* Use `go list` to retrieve package list, instead command line fu.
* Calls to `go test` pass packages explicitly, instead of `./...`.