### PR TITLE
disable CGO on all builds

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -122,7 +122,7 @@ packages:
 				if [ -d "$${cmd}" ]; then \
 					cd $${cmd}; \
 				fi; \
-				GOOS=$${os} GOARCH=$${arch} $(GOCMD) build -ldflags \
+				CGO_ENABLED=0 GOOS=$${os} GOARCH=$${arch} $(GOCMD) build -ldflags \
 				"-X main.version=$(TAG) -X main.build=$(BUILD) -X main.commit=$(COMMIT)" \
 				-o "$(BUILD_PATH)/$(PROJECT)_$${os}_$${arch}/`basename $${PWD}`" .; \
 				cd $(WORKDIR); \


### PR DESCRIPTION
* Set CGO_ENABLED=0
* With this, we can run binaries in Alpine without
  building in Alpine themselves.