### PR TITLE
fix builds when there are no go files in top level

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -63,7 +63,7 @@ else
 VENDOR_PATH =
 endif
 
-PACKAGES = $(shell go list | grep -v '/vendor/')
+PACKAGES = $(shell go list ./... | grep -v '/vendor/')
 
 # Rules
 


### PR DESCRIPTION
`go list` gives an error if there are no Go files in the
top level dir, so we switch it to `go list ./...`.