### PR TITLE
Improve Makefile.main handling

### DIFF
--- a/examples/ci/Makefile
+++ b/examples/ci/Makefile
@@ -3,16 +3,13 @@ PROJECT = ci
 COMMANDS = cmd/test
 #CODECOV_TOKEN = your codecov token
 
-# Including ci Makefile
-MAKEFILE = Makefile.main
-CI_REPOSITORY = https://github.com/src-d/ci.git
-CI_FOLDER = .ci
-
 # If you need to build more than one dockerfile, you can do so like this:
 # DOCKERFILES = Dockerfile_filename1:repositoryname1 Dockerfile_filename2:repositoryname2 ...
 
+# Including ci Makefile
+CI_REPOSITORY ?= https://github.com/src-d/ci.git
+CI_PATH ?= $(shell pwd)/.ci
+MAKEFILE := $(CI_PATH)/Makefile.main
 $(MAKEFILE):
-	@git clone --quiet $(CI_REPOSITORY) $(CI_FOLDER); \
-	cp $(CI_FOLDER)/$(MAKEFILE) .;
-
+	git clone --quiet --depth 1 $(CI_REPOSITORY) $(CI_PATH);
 -include $(MAKEFILE)


### PR DESCRIPTION
Let the user to define a custom place for the `CI` directory, and a custom repo address to fetch it.
Avoid copying `Makefile.main` over the root directory

### why?
Working with `docsrv` and many projects trying to download the [ci](https://github.com/src-d/ci/tree/master/examples/ci) again and again, I found more useful to keep the `Makefile.main` inside of the `.ci` directory, and specially letting the user to define where will it be located -> so it could be reused in many different places
