### PR TITLE
Add validate-commit target

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -170,6 +170,24 @@ test-coverage:
 	fi; \
 	bash <(curl -s https://codecov.io/bash) $${args}; \
 
+# This target checks if files in a repository have changed after code generation
+# how to generate files is up to project
+#
+# Example:
+#
+# validate-commit: generate-assets no-changes-in-commit
+#
+# generate-assets:
+#    yarn build
+#    go-bindata dist
+no-changes-in-commit:
+	git status --untracked-files=no --porcelain | grep -qe '..*'; \
+	if  [ $$? -eq 0 ] ; then \
+		git diff|cat; \
+		echo >&2 "generated assets are out of sync"; \
+		exit 2; \
+	fi
+
 clean:
 	rm -rf $(BUILD_PATH) $(VENDOR_PATH)
 	$(GOCLEAN) .

--- a/Makefile.main
+++ b/Makefile.main
@@ -48,7 +48,7 @@ GOCLEAN = $(GOCMD) clean
 GOINSTALL = $(GOCMD) install -v
 GOGET = $(GOCMD) get -v -t
 GOTEST = $(GOCMD) test -v
-CGO_ENABLED = ?= 0
+CGO_ENABLED ?= 0
 
 # Coverage
 COVERAGE_REPORT = coverage.txt


### PR DESCRIPTION
@dpordomingo suggested to add this target to CI, because every project which uses go-bindata would need it.