### PR TITLE
Allow to override PKG_OS

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -38,7 +38,7 @@ ifneq ($(origin CI), undefined)
 endif
 
 # Packages content
-PKG_OS = darwin linux
+PKG_OS ?= darwin linux
 PKG_ARCH = amd64
 
 # Go parameters


### PR DESCRIPTION
Cross-compilation doesn't work for bblfsh dashboard because of cgo.
I have redefined `PKG_OS = linux` in our Makefile but noticed common Makefile doesn't allow it only now 🤦‍♂️ 