### PR TITLE
Allow docker-push for a branch

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -106,8 +106,8 @@ docker-push:
 		dockerfile=`echo $${d} | cut -d":" -f 1`; \
 		repository=`echo $${d} | cut -d":" -f 2`; \
 		echo "Building dockerfile $$dockerfile for repository $$repository."; \
-		docker build -t $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$${repository}:$(TAG) -f $(WORKDIR)/$$dockerfile . && \
-		docker push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$${repository}:$(TAG); \
+		docker build -t $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$${repository}:$(BRANCH) -f $(WORKDIR)/$$dockerfile . && \
+		docker push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$${repository}:$(BRANCH); \
 		if [ $$? != 0 ]; then \
 			echo "Something went wrong pushing the image."; \
 			exit 1; \


### PR DESCRIPTION
I want to push images from a special experimental branch for testing purposes, it's more convenient than creating broken semver tags and updating that tag in k8s configuration.

According to travis-ci documentation `TRAVIS_BRANCH` is equal to `TRAVIS_TAG` when we build from a tag. Which means current behavior wouldn't be changed.
