### PR TITLE
Copy the binary, not the folder

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -126,7 +126,8 @@ $(COMMANDS):
 				$(GOBUILD) -o "$(BUILD_PATH)/$(PROJECT)_$${os}_$${arch}/`basename $@`" .; \
 			if [ "$(DOCKER_OS)" == "$${os}" ] && [ "$(DOCKER_ARCH)" == "$${arch}" ]; then \
 				echo "Linking matching OS/Arch binaries to "build/bin" folder"; \
-				cp -rf $(BUILD_PATH)/$(PROJECT)_$${os}_$${arch} $(BIN_PATH); \
+				mkdir -p $(BIN_PATH); \
+				cp -rf $(BUILD_PATH)/$(PROJECT)_$${os}_$${arch}/`basename $@` $(BIN_PATH); \
 			fi; \
 		done; \
 	done


### PR DESCRIPTION
When `COMMANDS` is a list of more than one, the first one is copied into `BIN_PATH` but the next ones are not but its building directories.

example:
`COMMANDS=cli/server cli/import`

The generated structure will be:
```
- build/bin
  - server
  - code-annotation_linux_amd64
    - server
    - import
- code-annotation_linux_amd64
```
instead of 
```
- build/bin
  - server
  - import
- code-annotation_linux_amd64
```