### PR TITLE
Sets the correct TAG for drone CI

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -30,12 +30,19 @@ COMMIT ?= $(shell git log --format='%H' -n 1 | cut -c1-10)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 # travis CI
-ifneq ($(origin CI), undefined)
+ifeq ($(TRAVIS), true)
 	COMMIT := $(shell echo $(TRAVIS_COMMIT) | cut -c1-10)
 	BRANCH := $(TRAVIS_BRANCH)
 	TAG := $(TRAVIS_TAG)
 	WORKDIR := $(TRAVIS_BUILD_DIR)
 	BUILD_PATH := $(WORKDIR)/build
+endif
+
+# drone CI
+ifeq ($(DRONE), true)
+	COMMIT := $(shell echo $(DRONE_COMMIT) | cut -c1-10)
+	BRANCH := $(DRONE_BRANCH)
+	TAG := $(DRONE_TAG)
 endif
 
 # Packages content


### PR DESCRIPTION
Sets TAG, COMMIT, BRANCH for drone CI.
Untested, based on: http://readme.drone.io/usage/environment-reference/

Needed by the code-annotation project, context here: https://github.com/src-d/code-annotation/issues/159#issuecomment-368648245