### PR TITLE
Set VERSION for Drone CI

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -42,10 +42,19 @@ DEV_PREFIX := dev
 VERSION ?= $(DEV_PREFIX)-$(COMMIT)$(GIT_DIRTY)
 
 # Travis CI
-ifneq ($(origin CI), undefined)
+ifeq ($(TRAVIS), true)
 	WORKDIR := $(TRAVIS_BUILD_DIR)
 	BUILD_PATH := $(WORKDIR)/build
 	VERSION := $(TRAVIS_BRANCH)
+endif
+
+# Drone CI
+ifeq ($(DRONE), true)
+	ifeq ($(DRONE_BUILD_EVENT), tag)
+		VERSION := $(DRONE_TAG)
+	else
+		VERSION := $(DRONE_BRANCH)
+	endif
 endif
 
 # Packages content


### PR DESCRIPTION
Sets VERSION for drone CI.
Untested, based on: http://readme.drone.io/usage/environment-reference/ and https://docs.travis-ci.com/user/environment-variables/

Needed by the code-annotation project, context here: https://github.com/src-d/code-annotation/issues/159#issuecomment-368648245