### PR TITLE
Replace '/' char from version

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -188,7 +188,8 @@ packages: build
 	@cd $(BUILD_PATH); \
 	for os in $(PKG_OS); do \
 		for arch in $(PKG_ARCH); do \
-			tar -cvzf $(PROJECT)_$(VERSION)_$${os}_$${arch}.tar.gz $(PROJECT)_$${os}_$${arch}/; \
+			TAR_VERSION=`echo $(VERSION) | tr "/" "-"`; \
+			tar -cvzf $(PROJECT)_$(TAR_VERSION)_$${os}_$${arch}.tar.gz $(PROJECT)_$${os}_$${arch}/; \
 		done; \
 	done
 


### PR DESCRIPTION
when a branch has the `/` char and it is tested in Travis, the `/` char causes a conflict
(example in the [release branches](https://github.com/src-d/guide/blob/master/engineering/continuous-delivery.md#release-branch))
```shell
> tar -cvzf $(PROJECT)_$(TAR_VERSION)_$${os}_$${arch}.tar.gz $(PROJECT)_$${os}_$${arch}/;
tar (child): code-annotation_release/v0.0.8_linux_amd64.tar.gz: Cannot open: No such file or directory
```
