### PR TITLE
Let the validation to check untracked files

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -197,9 +197,10 @@ clean:
 	$(GOCLEAN) .
 
 no-changes-in-commit:
-	git status --untracked-files=no --porcelain | grep -qe '..*'; \
+	@git status --untracked-files=normal --porcelain | grep -qe '..*'; \
 	if  [ $$? -eq 0 ] ; then \
 		git diff|cat; \
+		git status --untracked-files=normal --porcelain; \
 		echo >&2 "generated assets are out of sync"; \
 		exit 2; \
 	fi

--- a/README.md
+++ b/README.md
@@ -92,14 +92,16 @@ customizable to cover edge cases of complex builds.
 
 ### Rule `no-changes-in-commit`
 
-The `no-changes-in-commit` rule checks if files in the repository have changed.
-Useful to detect non-commited generated code for projects based on `go generate`
-or `gobindata`.
+The `no-changes-in-commit` rule checks if not ignored files in the repository have changed or have been added.
+Useful to detect non-commited generated code for projects based on `go generate`, `gobindata` or `dep ensure`.
 
 Example:
 
-```
-validate-commit: generate-assets no-changes-in-commit
+```shell
+validate-commit: dependencies generate-assets no-changes-in-commit
+
+dependencies:
+  dep ensure
 
 generate-assets:
   yarn build


### PR DESCRIPTION
If the changes are over untracked files, the validation passes, what might be wrong in some cases (ie. for go `vendor` dir).

The validation will fail if there are untracked files when the target is ran with:
```shell
UNTRACKED_MODE=normal make no-changes-in-commit 
```

For existent projects, not using this new configuration, there is no change at all.