### PR TITLE
Use defined CGO_ENABLED

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -134,7 +134,7 @@ $(COMMANDS):
 	for os in $(PKG_OS); do \
 		for arch in $(PKG_ARCH); do \
 			mkdir -p $(BUILD_PATH)/$(PROJECT)_$${os}_$${arch}; \
-			$(GO_BUILD_ENV) GOOS=$${os} GOARCH=$${arch} \
+			$(GO_BUILD_ENV) CGO_ENABLED=$(CGO_ENABLED) GOOS=$${os} GOARCH=$${arch} \
 				$(GOBUILD) -o "$(BUILD_PATH)/$(PROJECT)_$${os}_$${arch}/`basename $@`" .; \
 			if [ "$(DOCKER_OS)" == "$${os}" ] && [ "$(DOCKER_ARCH)" == "$${arch}" ]; then \
 				echo "Linking matching OS/Arch binaries to "build/bin" folder"; \


### PR DESCRIPTION
With the current state of `ci::v1` and building a go project with `make build`, and running the generated binary inside an `alpine:3.7` container, I get the following error:
```
standard_init_linux.go:178: exec user process caused "no such file or directory"
```
It seems that CGO_ENABLED is not properly read from the passed make vars, so it should be explicitly passed to the build command.