### PR TITLE
Fix version variable

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -189,7 +189,7 @@ packages: build
 	for os in $(PKG_OS); do \
 		for arch in $(PKG_ARCH); do \
 			TAR_VERSION=`echo $(VERSION) | tr "/" "-"`; \
-			tar -cvzf $(PROJECT)_$(TAR_VERSION)_$${os}_$${arch}.tar.gz $(PROJECT)_$${os}_$${arch}/; \
+			tar -cvzf $(PROJECT)_$${TAR_VERSION}_$${os}_$${arch}.tar.gz $(PROJECT)_$${os}_$${arch}/; \
 		done; \
 	done
 


### PR DESCRIPTION
This PR fixes a bug introduced by [`Makefile.main::packages#192](https://github.com/src-d/ci/pull/60/files#diff-4feed128d77fca6949f1938f81fe7e76R192) because oneliners defining and using a new variable use a different syntax.