### PR TITLE
test: move to Go 1.10.x and fix example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9
+  - 1.10.x
 
 script:
   - ./.tests.bash

--- a/examples/basic/example.go
+++ b/examples/basic/example.go
@@ -6,7 +6,7 @@ import (
 )
 
 func HelloWorld(build, version, commit string) {
-	fmt.Println("Hello World! Application\n")
+	fmt.Println("Hello World! Application")
 	fmt.Println("Build information:")
 	fmt.Printf("\tBuild: %s\n\tVersion: %s\n\tCommit: %s\n", build, version, commit)
 }


### PR DESCRIPTION
Go 1.10.x tests run go vet automatically, so the example needs a small fix to run.