### PR TITLE
test: tests were testing previous version, not PR

### DIFF
--- a/.tests.bash
+++ b/.tests.bash
@@ -5,7 +5,8 @@ EXAMPLES="examples/basic"
 for example in ${EXAMPLES} ; do
 	echo "Running $example"
 
-	cp Makefile.main ${example}/Makefile.main
+	mkdir -p ${example}/.ci
+	cp Makefile.main ${example}/.ci/
 	pushd $example &> /dev/null
 
 	make dependencies


### PR DESCRIPTION
Because of an error in the copy command in .tests.bash,
Makefile of the example was cloning src-d/ci. So tests
were not really testing whatever is in the build, but
whatever is already merged.

Signed-off-by: Santiago M. Mola <santi@mola.io>