### PR TITLE
add Windows support, fixes #52

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,11 @@
+version: "{build}"
+image: Visual Studio 2017
+platform: x64
+clone_folder: C:\gopath\src\github.com\src-d\ci
+environment:
+  GOPATH: C:\gopath
+build: off
+test_script:
+  - set PATH=%GOPATH%\bin;C:\go\bin;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;C:\msys64\usr\bin;%PATH%;"C:\Program Files\Git\mingw64\bin"
+  - bash .tests.bash
+deploy: off

--- a/.tests.bash
+++ b/.tests.bash
@@ -1,4 +1,10 @@
-#!/bin/bash -xe
+#!/bin/bash
+set -xe
+
+MAKE=make
+if [[ ! -z ${APPVEYOR} ]]; then
+	MAKE=mingw32-make
+fi
 
 EXAMPLES="examples/basic"
 
@@ -8,13 +14,13 @@ for example in ${EXAMPLES} ; do
 	cp Makefile.main ${example}/Makefile.main
 	pushd $example &> /dev/null
 
-	make dependencies
+	"${MAKE}" dependencies
 
-	make test
+	"${MAKE}" test
 
-	make test-coverage
+	"${MAKE}" test-coverage
 
-	make packages
+	"${MAKE}" packages
 
 	popd &> /dev/null
 done

--- a/examples/basic/Makefile
+++ b/examples/basic/Makefile
@@ -8,7 +8,7 @@ COMMANDS = cmd/test
 # Including ci Makefile
 CI_REPOSITORY ?= https://github.com/src-d/ci.git
 CI_BRANCH ?= v1
-CI_PATH ?= $(shell pwd)/.ci
+CI_PATH ?= .ci
 MAKEFILE := $(CI_PATH)/Makefile.main
 $(MAKEFILE):
 	git clone --quiet --depth 1 -b $(CI_BRANCH) $(CI_REPOSITORY) $(CI_PATH);


### PR DESCRIPTION
* Add Appveyor CI, fix tests of src-d/ci itself to run on Appveyor.
* example: Avoid subshell on Makefile before including Makefile.main. This fixes the build for mingw32-make on Windows. Alternative might be setting SHELL=/bin/bash on Makefile, but avoiding the subshell is just simpler and works.

Signed-off-by: Santiago M. Mola <santi@mola.io>