### PR TITLE
external services (postgresql, rabbitmq) setup

### DIFF
--- a/.tests.bash
+++ b/.tests.bash
@@ -23,5 +23,7 @@ for example in ${EXAMPLES} ; do
 
 	"${MAKE}" packages
 
+	POSTGRESQL_VERSION=9.6 RABBITMQ_VERSION=any "${MAKE}" prepare-services
+
 	popd &> /dev/null
 done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+sudo: required
 
 go:
   - 1.10.x
@@ -6,6 +7,8 @@ go:
 os:
   - linux
   - osx
+
+osx_image: xcode9.3
 
 script:
   - ./.tests.bash

--- a/Makefile.main
+++ b/Makefile.main
@@ -23,6 +23,10 @@ DOCKER_PUSH_LATEST ?=
 DOCKER_OS ?= $(shell docker version -f "{{.Server.Os}}")
 DOCKER_ARCH ?= $(shell docker version -f "{{.Server.Arch}}")
 
+# Backend services
+POSTGRESQL_VERSION ?=
+RABBITMQ_VERSION ?=
+
 # Checking mandatory variables
 ifndef PROJECT
 $(error ERROR! The PROJECT variable cannot be empty)
@@ -33,6 +37,7 @@ WORKDIR := $(PWD)
 BUILD_PATH := $(WORKDIR)/build
 BIN_PATH := $(BUILD_PATH)/bin
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
+CI_PATH ?= $(WORKDIR)/.ci
 
 # Build information
 BUILD ?= $(shell date +"%m-%d-%Y_%H_%M_%S")
@@ -205,10 +210,20 @@ no-changes-in-commit:
 		exit 2; \
 	fi
 
+export POSTGRESQL_VERSION RABBITMQ_VERSION
+ifdef APPVEYOR
+prepare-services:
+	pwsh -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/smola/ci-tricks/master/get.ps1'))"
+else
+prepare-services:
+	wget -qO - https://raw.githubusercontent.com/smola/ci-tricks/master/get.sh | bash
+endif
+
 .PHONY: dependencies $(DEPENDENCIES) \
 		build $(COMMANDS) \
 		test test-race test-coverage \
 		docker-login docker-validate docker-build docker-push \
 		packages \
 		clean \
-		no-changes-in-commit
+		no-changes-in-commit \
+		prepare-services

--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ docker images. The images are tagged with the current value of `VERSION`. If
 `DOCKER_PUSH_LATEST` is provided with any value, a `latest` tag is created and
 pushed too.
 
+### External service setup
+
+The `ci-install` rule sets up external services consistently across different CI providers
+and operating systems. External services to setup are specified with environment variables:
+
+* `POSTGRESQL_VERSION`: if not empty, PostgreSQL will be installed or started. Check supported versions on
+   [Travis CI](https://docs.travis-ci.com/user/database-setup/#Using-a-different-PostgreSQL-Version),
+   [Appveyor](https://www.appveyor.com/docs/services-databases/#postgresql) and [Homebrew](http://formulae.brew.sh/formula/). Currently `9.4`, `9.5` and `9.6 are supported across all of them.
+* `RABBITMQ_VERSION`, if not empty, RabbitMQ will be installed or started. Currently `any` is the only supported value.
+
+[Check all supported services and versions.](https://github.com/smola/ci-tricks/#tricks)
+
 ## Notes
 
 ### Version calculation


### PR DESCRIPTION
This PR adds a new rule `ci-install` to prepare external services for integration tests. This works consistently across Travis/Linux, Travis/macOS and Appveyor/Windows. On the install phase, you can just add:

```yaml
  - make ci-install
```

Installed services are specified by environment variables, so it is easy to use them in the build matrix specification.

Currently, we support PostgreSQL and RabbitMQ. These are configured with environment variables:

* `POSTGRESQL_VERSION`: should work with values `9.4`, `9.5` and `9.6` on all platforms (`10` coming up, see below).
* `RABBITMQ_VERSION`: only works with value `any` at the moment.

## FAQ

### Why not using services provided by CI service?

There are two main issues with using services provided out of the box for Travis CI and Appveyor:

1. Not all of them all supported across all platforms. For example, RabbitMQ is provided only on Travis/Linux.
2. Even when they are, such as PostgreSQL 9.6, they do not work consistently across all platforms. See https://github.com/travis-ci/travis-ci/issues/1875

With our own setup phase, we can provide the same services and versions consistently across Travis/Linux, Travis/macOS and Appveyor/Windows.

Note that, whenever they are available, we reuse existing installs for the services to save build times.

### Why not Docker?

The initial plan was, indeed, using Docker for all backend services. This could have been done either by `src-d/ci` itself or by the project itself with something like docker-compose.

The problem? Docker is not provided on Travis CI for macOS, and the Docker service available on Appveyor for Windows is actually for Windows containers.

### Can I have PostgreSQL 10?

Not on Travis/Linux, but they have planned support for it: https://github.com/travis-ci/travis-ci/issues/8537

If we need it before they release it, we can add support on `src-d/ci` by adding a custom installation. But for this PR, I chose to keep it simple.

### Can I have specific RabbitMQ versions?

Not yet. On Travis/Linux we use whatever version is installed by default. On Travis/macOS we use latest version available on Homebrew. On Appveyor/Windows we use latest version available on Chocolatey.

### I want to add a new service!

Brace yourself. Code changes are relatively simple (see this PR), but be prepared to find a sane way to setup the service on Travis/Linux, Travis/macOS and Appveyor/Windows.

For all of them, prefer preinstalled services whenever they are available. When they are not, prefer fast installs (usually binary packages). Your first stop would be:

* Travis/Linux: apt
* Travis/macOS: Homebrew
* Travis/Windows: Chocolatey
