### PR TITLE
add hooks for ci configurations into Makefile.main

### DIFF
--- a/.tests.bash
+++ b/.tests.bash
@@ -15,11 +15,9 @@ for example in ${EXAMPLES} ; do
 	cp Makefile.main ${example}/.ci/
 	pushd $example &> /dev/null
 
-	"${MAKE}" dependencies
+	"${MAKE}" ci-install
 
-	"${MAKE}" test
-
-	"${MAKE}" test-coverage
+	"${MAKE}" ci-script
 
 	"${MAKE}" packages
 

--- a/Makefile.main
+++ b/Makefile.main
@@ -96,6 +96,9 @@ COVERAGE_MODE = atomic
 PACKAGES = $(shell go list ./... | grep -v '/vendor/')
 
 # Rules
+
+.SUFFIXES:
+
 dependencies: $(DEPENDENCIES)
 	$(GOGET) -t ./...
 
@@ -219,6 +222,12 @@ prepare-services:
 	wget -qO - https://raw.githubusercontent.com/smola/ci-tricks/master/get.sh | bash
 endif
 
+ci-install: | prepare-services dependencies
+	@echo
+
+ci-script: | test-coverage codecov packages
+	@echo
+
 .PHONY: dependencies $(DEPENDENCIES) \
 		build $(COMMANDS) \
 		test test-race test-coverage \
@@ -226,4 +235,5 @@ endif
 		packages \
 		clean \
 		no-changes-in-commit \
-		prepare-services
+		prepare-services \
+		ci-script ci-install

--- a/Makefile.main
+++ b/Makefile.main
@@ -225,8 +225,13 @@ endif
 ci-install: | prepare-services dependencies
 	@echo
 
+ifeq ($($strip $(COMMANDS)),)
+ci-script: | test-coverage codecov
+	@echo
+else
 ci-script: | test-coverage codecov packages
 	@echo
+endif
 
 .PHONY: dependencies $(DEPENDENCIES) \
 		build $(COMMANDS) \

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ For that, in travis, you can use the `env`. If your project is public, make sure
 
 ## Tasks
 
+### Main hooks
+
+These rules are meant to be used as is on their corresponding CI phase:
+
+* `ci-install` (for Travis and Appveyor `install` phase): runs `dependencies`.
+* `ci-script` (for Travis `script` and Appveyor `test_script` phases): runs `test-coverage`, `codecov` and `packages`.
+
 ### Tests packages
 
 There are thee rules available for testing:

--- a/examples/basic/.appveyor.yml
+++ b/examples/basic/.appveyor.yml
@@ -1,0 +1,13 @@
+version: "{build}"
+image: Visual Studio 2017
+platform: x64
+clone_folder: C:\gopath\src\github.com\src-d\ci
+environment:
+  GOPATH: C:\gopath
+install:
+  - set PATH=%GOPATH%\bin;C:\go\bin;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;C:\msys64\usr\bin;%PATH%;"C:\Program Files\Git\mingw64\bin"
+  - mingw32-make ci-install
+build: off
+test_script:
+  - mingw32-make ci-script
+deploy: off

--- a/examples/basic/.travis.yml
+++ b/examples/basic/.travis.yml
@@ -1,36 +1,42 @@
 language: go
 
-go:
-  - 1.9
+# NOTE: If testing a single Go version, define it here and skip the `go`
+#       parameter in the job matrix definition:
+# go: 1.10.x
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - go: tip
-
+# Some default values, these can be skipped in the matrix definition.
 sudo: required
+dist: trusty
 
-services:
-  - docker
-
+# Scripts for the default test stage.
 install:
-  - make dependencies
+  - make ci-install
 
 script:
-  - make test-coverage
-  - make codecov
+  - make ci-script
 
-before_deploy:
-  - make packages
-
-deploy:
-  provider: releases
-  api_key: $GITHUB_TOKEN
-  file_glob: true
-  file: build/*.tar.gz
-  skip_cleanup: true
-  on:
-    tags: true
-
-after_deploy:
-  - make docker-push
+jobs:
+  include:
+    # Matrix for the default test stage. It runs in parallel.
+    - {os: linux,                        go: 1.9.x}
+    - {os: linux,                        go: 1.10.x}
+    - {os: osx,   xcode_image: xcode8.3, go: 1.9.x}
+    - {os: osx,   xcode_image: xcode8.3, go: 1.10.x}
+    - {os: osx,   xcode_image: xcode9.3, go: 1.9.x}
+    - {os: osx,   xcode_image: xcode8.3, go: 1.10.x}
+    # Deploy stage, running only on tags.
+    - stage: deploy
+      if: tag IS present
+      os: linux
+      services:
+        - docker
+      script:
+        - make packages
+      deploy:
+        provider: releases
+        api_key: $GITHUB_TOKEN
+        file_glob: true
+        file: build/*.tar.gz
+        skip_cleanup: true
+      after_deploy:
+        - make docker-push


### PR DESCRIPTION
Adds two new targets: `ci-install` and `ci-script`. These are meant to be the 
only targets running in the install and test phases both on `.travis.yml` and 
`appveyor.yml`.

The relevant `.travis.yml` section would look like:

```yaml
install:
  - make ci-install
script:
  - make ci-script
```

And `appveyor.yml` would be: 

```yaml
install:
  - set PATH=%GOPATH%\bin;C:\go\bin;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;C:\msys64\usr\bin;%PATH%;"C:\Program Files\Git\mingw64\bin"
  - mingw32-make ci-install
test_script:
  - mingw32-make ci-script
```

The behaviour of these rules is as follows:

* `ci-install` always runs `dependencies`.

* `ci-script` runs `test-coverage`, `codecov` and `packages`.

This commit also changes the example `.travis.yml` to use multi-stage builds, which offer
more flexibility to define build matrices, conditional stages and so on. The deploy section
did not receive any significant change yet, but it might be changed to a `ci-*`-style rule
too in a further change to simplify the CI definition.
