### PR TITLE
download ci-tricks to CI_PATH

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -216,9 +216,11 @@ no-changes-in-commit:
 export POSTGRESQL_VERSION RABBITMQ_VERSION
 ifdef APPVEYOR
 prepare-services:
+	cd $(CI_PATH) && \
 	pwsh -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/smola/ci-tricks/master/get.ps1'))"
 else
 prepare-services:
+	cd $(CI_PATH) && \
 	wget -qO - https://raw.githubusercontent.com/smola/ci-tricks/master/get.sh | bash
 endif
 


### PR DESCRIPTION
This avoids no-changes-in-commit rule failing because the ci-tricks binary is present. Since all projects ignore the .ci directory, it is safer to use it for temporary files.

Signed-off-by: Santiago M. Mola <santi@mola.io>