### PR TITLE
Set CI version name for tag builds only

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -46,17 +46,13 @@ DEV_PREFIX := dev
 VERSION ?= $(DEV_PREFIX)-$(COMMIT)$(GIT_DIRTY)
 
 # Travis CI
-ifeq ($(TRAVIS), true)
-	VERSION := $(TRAVIS_BRANCH)
+ifneq ($(TRAVIS_TAG), )
+	VERSION := $(TRAVIS_TAG)
 endif
 
 # Drone CI
-ifeq ($(DRONE), true)
-	ifeq ($(DRONE_BUILD_EVENT), tag)
-		VERSION := $(DRONE_TAG)
-	else
-		VERSION := $(DRONE_BRANCH)
-	endif
+ifeq ($(DRONE_BUILD_EVENT), tag)
+	VERSION := $(DRONE_TAG)
 endif
 
 # Packages content


### PR DESCRIPTION
Required by https://github.com/src-d/gitbase-playground/issues/183.

Right now gitbase-playground is deployed in staging for each commit, and the binary always reports the version as `master`.

With this PR the `VERSION` is changed in Travis or Drone only when the build is triggered by a tag.
This means that for any other build, version will be `dev-commithash` instead of the branch name.

