### PR TITLE
Improvement/add godep ensure

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -88,6 +88,11 @@ GOTEST = $(GOCMD) test $(GO_TEST_ARGS)
 GOTEST_RACE = $(GOTEST) -race
 GOCLEAN = $(GOCMD) clean
 
+ifdef APPVEYOR
+	GODEP := $(CI_PATH)/dep.exe
+endif
+GODEP ?= $(CI_PATH)/dep
+
 # Coverage
 COVERAGE_REPORT = coverage.txt
 COVERAGE_PROFILE = profile.out
@@ -212,6 +217,12 @@ no-changes-in-commit:
 		echo >&2 "generated assets are out of sync"; \
 		exit 2; \
 	fi
+
+godep:
+	export INSTALL_DIRECTORY=$(CI_PATH) ; \
+	test -f $(GODEP) || \
+		curl https://raw.githubusercontent.com/golang/dep/master/install.sh | bash ; \
+	$(GODEP) ensure -v
 
 export POSTGRESQL_VERSION RABBITMQ_VERSION
 ifdef APPVEYOR

--- a/README.md
+++ b/README.md
@@ -114,13 +114,14 @@ customizable to cover edge cases of complex builds.
 The `no-changes-in-commit` rule checks if not ignored files in the repository have changed or have been added.
 Useful to detect non-commited generated code for projects based on `go generate`, `gobindata` or `dep ensure`.
 
+`dep ensure` can be executed with rule `godep`. It downloads the latest version of the tool and executes it.
+
 Example:
 
 ```shell
 validate-commit: dependencies generate-assets no-changes-in-commit
 
-dependencies:
-  dep ensure
+dependencies: godep
 
 generate-assets:
   yarn build


### PR DESCRIPTION
Tested in linux and Windows (Appveyor). It should also work in MacOSX. It's executed in verbose mode as the info may be useful when something goes wrong.

Fixes #83