### PR TITLE
Use -lt to check args length

### DIFF
--- a/scripts/helm-deploy.sh
+++ b/scripts/helm-deploy.sh
@@ -4,7 +4,8 @@
 
 set -eo pipefail
 
-if [[ $# < 4 ]]; then
+
+if [[ $# -lt 4 ]]; then
     echo "Usage: $0 release chart namespace service-account [helm args]"
     exit 1
 fi


### PR DESCRIPTION
Use `-lt` to check args length, before `<` was used which compares string values which makes this happen

```bash
$ [[ 11 < 4 ]] && echo hola
hola
```