### PR TITLE
Use COPY instead of ADD in Dockerfile

### DIFF
--- a/examples/static-site/Dockerfile
+++ b/examples/static-site/Dockerfile
@@ -2,4 +2,4 @@ FROM abiosoft/caddy
 
 COPY Caddyfile /etc/Caddyfile
 # change build by the directory where your generated static site is
-ADD build /var/www/public
+COPY build /var/www/public


### PR DESCRIPTION
Hello,

The use of COPY is preferred over ADD when additional functionalities of ADD are not being used (like spraying the contents of a tar in a folder).

Ref:https://docs.docker.com/engine/articles/dockerfile_best-practices/#add-or-copy

Thanks.