### PR TITLE
success msg when nothing pending to be committed

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -240,6 +240,8 @@ no-changes-in-commit:
 		git status --untracked-files=normal --porcelain; \
 		echo >&2 "generated assets are out of sync"; \
 		exit 2; \
+	else \
+		echo there is nothing pending to be commited; \
 	fi
 
 godep:


### PR DESCRIPTION
When the user runs `make no-changes-in-commit` the output is empty if there is nothing to be committed.
It would be more meaning full if there would be an output saying so.

That way, it could be easily recommended in `CONTRIBUTING.md` something like the following:

<details>
<h3>Generated Code</h3>

Before submitting a pull request make sure all the generated code changes are also committed.

To do so, you can generate all needed code and then ensure that nothing is pending to be committed running:

```shell
$ make generate
$ make no-changes-in-commit
```
</details>

without being necessary to explain that the output of the command must be _empty_ if it succeeded
