### PR TITLE
Update default Helm version to 2.14.1

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -109,7 +109,7 @@ COVERAGE_MODE = atomic
 PACKAGES = $(shell go list ./... | grep -v '/vendor/')
 
 # Helm deployment information
-HELM_VERSION ?= v2.8.2
+HELM_VERSION ?= v2.14.1
 HELM_DEPLOY_SCRIPT ?= https://raw.githubusercontent.com/src-d/ci/v1/scripts/helm-deploy.sh
 HELM_RELEASE ?=
 HELM_CHART ?=


### PR DESCRIPTION
This updates the install to use the 2.14.1 version of Helm which we will use on our clusters.