### PR TITLE
copy the binary of the current OS and architecture to bin

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -28,6 +28,43 @@ BUILD_PATH := $(WORKDIR)/build
 BUILD ?= $(shell date +"%m-%d-%Y_%H_%M_%S")
 COMMIT ?= $(shell git log --format='%H' -n 1 | cut -c1-10)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
+CURRENT_OS :=
+CURRENT_ARCH :=
+ifeq ($(OS),Windows_NT)
+	CURRENT_OS = windows
+	ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+		CURRENT_ARCH = amd64
+	endif
+	ifeq ($(PROCESSOR_ARCHITECTURE),x86)
+		CURRENT_ARCH = 386
+	endif
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		CURRENT_OS = linux
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		CURRENT_OS = darwin
+	endif
+	UNAME_P := $(shell uname -p)
+	ifeq ($(UNAME_P),x86_64)
+		CURRENT_ARCH = amd64
+	endif
+	ifneq ($(filter %86,$(UNAME_P)),)
+		CURRENT_ARCH = 386
+	endif
+	ifneq ($(filter arm%,$(UNAME_P)),)
+		CURRENT_ARCH = arm
+	endif
+endif
+
+ifndef CURRENT_OS
+$(error ERROR! Your operating system is not supported)
+endif
+
+ifndef CURRENT_ARCH
+$(error ERROR! Your architecture is not supported)
+endif
 
 # travis CI
 ifneq ($(origin CI), undefined)
@@ -151,7 +188,7 @@ packages:
 			tar -cvzf $(PROJECT)_$(TAG)_$${os}_$${arch}.tar.gz $(PROJECT)_$${os}_$${arch}/; \
 		done; \
 	done; \
-	cp -r $(BUILD_PATH)/$(PROJECT)_linux_amd64 $(WORKDIR)/bin; \
+	cp -r $(BUILD_PATH)/$(PROJECT)_$(CURRENT_OS)_$(CURRENT_ARCH) $(WORKDIR)/bin; \
 
 post-run:
 	@for script in $(POSTRUN); do \


### PR DESCRIPTION
Right now, only linux amd64 binary is copied to the `bin` folder. But if for some reason that binary cannot be built (because you're building from another operating system, for example, and it can't be cross-compiled), `make packages` will fail.

This makes sure the binary that's copied is the one corresponding to the current operating system and architecture.