### PR TITLE
Force docker to pull FROM images when building

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -198,7 +198,7 @@ docker-build: $(COMMANDS)
 	for d in $(DOCKERFILES); do \
 		dockerfile=`echo $${d} | cut -d":" -f 1`; \
 		repository=`echo $${d} | cut -d":" -f 2`; \
-		docker build -t $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$${repository}:$(VERSION) -f $$dockerfile .; \
+		docker build --pull -t $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$${repository}:$(VERSION) -f $$dockerfile .; \
 	done;
 
 docker-push: docker-login docker-build


### PR DESCRIPTION
same as in https://github.com/src-d/ci/pull/106

Otherwise, we're building using old versions of our FROM images.
some info: https://www.databasesandlife.com/docker-build-pull-option
