### PR TITLE
add tests with race conditions to ci-script

### DIFF
--- a/Makefile.main
+++ b/Makefile.main
@@ -2,6 +2,7 @@
 PROJECT ?=
 COMMANDS ?=
 DEPENDENCIES ?=
+TEST_RACE ?=
 
 # Default shell
 SHELL := /bin/bash
@@ -132,7 +133,11 @@ test:
 	$(GOTEST) $(PACKAGES)
 
 test-race:
-	$(GOTEST_RACE) $(PACKAGES)
+	if [ -z "$(TEST_RACE)" ]; then \
+		echo -e "\033[0;31mWARNING! Testing with race detection is disabled, please consider toggling it on setting TEST_RACE ?= true"; \
+	else \
+		$(GOTEST_RACE) $(PACKAGES); \
+	fi; \
 
 test-coverage:
 	echo "" > $(COVERAGE_REPORT); \
@@ -266,10 +271,10 @@ ci-install: | prepare-services dependencies
 	@echo
 
 ifeq ($($strip $(COMMANDS)),)
-ci-script: | test-coverage codecov
+ci-script: | test-coverage codecov test-race
 	@echo
 else
-ci-script: | test-coverage codecov packages
+ci-script: | test-coverage codecov test-race packages
 	@echo
 endif
 


### PR DESCRIPTION
Currently almost none of repos that use CI use to run `test-race` command.

This attitude hides race conditions that can be revealed during debug of some other feature([example](https://github.com/src-d/go-borges/pull/89)) or in production in the worst case.

IMHO we should know about all race conditions that we have in our repositories.
If there're some known race-conditions that are kept "by design" or come from third-party library, then corresponding tests can be excluded like in [example](https://golang.org/doc/articles/race_detector.html#Excluding_Tests)

I understand that after this PR is merged a lot of CI builds will fail, but I believe that we need to deal with it on the early stages.

Please correct me if I'm wrong.

Signed-off-by: lwsanty <lwsanty@gmail.com>